### PR TITLE
Move config screen factory cache initialisation on first use.

### DIFF
--- a/src/main/java/com/plusls/MasaGadget/MasaGadgetMod.java
+++ b/src/main/java/com/plusls/MasaGadget/MasaGadgetMod.java
@@ -27,6 +27,5 @@ public class MasaGadgetMod implements ClientModInitializer {
         MouseScrollInputHandler.register();
         ConfigManager.getInstance().registerConfigHandler(ModInfo.MOD_ID, new Configs());
         InputEventHandler.getKeybindManager().registerKeybindProvider(InputHandler.getInstance());
-        MasaGuiUtil.init();
     }
 }

--- a/src/main/java/com/plusls/MasaGadget/malilib/fastSwitchMasaConfigGui/MasaGuiUtil.java
+++ b/src/main/java/com/plusls/MasaGadget/malilib/fastSwitchMasaConfigGui/MasaGuiUtil.java
@@ -6,7 +6,6 @@ import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import com.terraformersmc.modmenu.util.ModMenuApiMarker;
 import fi.dy.masa.malilib.gui.GuiConfigsBase;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.minecraft.client.MinecraftClient;
@@ -16,14 +15,31 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MasaGuiUtil {
-    public static Map<ConfigScreenFactory<?>, String> masaGuiData = new HashMap<>();
-    public static Map<Class<?>, ConfigScreenFactory<?>> masaGuiClassData = new HashMap<>();
 
-    public static void init() {
-        ClientLifecycleEvents.CLIENT_STARTED.register(MasaGuiUtil::initMasaModScreenList);
+
+    private final static Map<ConfigScreenFactory<?>, String> masaGuiData = new HashMap<>();
+    private final static Map<Class<?>, ConfigScreenFactory<?>> masaGuiClassData = new HashMap<>();
+    private static boolean initialised = false;
+
+
+    public static Map<ConfigScreenFactory<?>, String> getMasaGuiData() {
+        if (!initialised) {
+            initMasaModScreenList();
+        }
+        return masaGuiData;
     }
 
-    public static void initMasaModScreenList(MinecraftClient client) {
+    public static Map<Class<?>, ConfigScreenFactory<?>> getMasaGuiClassData() {
+        if (!initialised) {
+            initMasaModScreenList();
+        }
+        return masaGuiClassData;
+    }
+
+
+    private static void initMasaModScreenList() {
+        initialised = true;
+        MinecraftClient client = MinecraftClient.getInstance();
         if (!MasaGadgetMixinPlugin.isModmenu) {
             return;
         }

--- a/src/main/java/com/plusls/MasaGadget/mixin/malilib/fastSwitchMasaConfigGui/MixinGuiConfigBase.java
+++ b/src/main/java/com/plusls/MasaGadget/mixin/malilib/fastSwitchMasaConfigGui/MixinGuiConfigBase.java
@@ -29,7 +29,7 @@ public abstract class MixinGuiConfigBase extends GuiListBase<GuiConfigsBase.Conf
     @Shadow
     protected Screen parentScreen;
     private final MyWidgetDropDownList<ConfigScreenFactory<?>> masaModGuiList = new MyWidgetDropDownList<>(GuiUtils.getScaledWindowWidth() - 145, 10, 120, 18, 200, 10,
-            MasaGuiUtil.masaGuiData.keySet().stream().toList(), MasaGuiUtil.masaGuiData::get,
+            MasaGuiUtil.getMasaGuiData().keySet().stream().toList(), MasaGuiUtil.getMasaGuiData()::get,
             configScreenFactory -> GuiBase.openGui(configScreenFactory.create(this.parentScreen)),
             configScreenFactory -> Configs.Malilib.FAST_SWITCH_MASA_CONFIG_GUI.getBooleanValue());
 
@@ -39,7 +39,7 @@ public abstract class MixinGuiConfigBase extends GuiListBase<GuiConfigsBase.Conf
 
     @Inject(method = "initGui", at = @At(value = "RETURN"))
     public void postInitGui(CallbackInfo ci) {
-        masaModGuiList.setSelectedEntry(MasaGuiUtil.masaGuiClassData.get(this.getClass()));
+        masaModGuiList.setSelectedEntry(MasaGuiUtil.getMasaGuiClassData().get(this.getClass()));
         this.addWidget(masaModGuiList);
     }
 


### PR DESCRIPTION
Fix for #23.

But also it's more likely for e player to not open any configuration screen for a given play session. So there is no point of creating the cache during startup.