### PR TITLE
Fix ConfigScreenEntrypoint introduced by MaFgLib not supporting `fastSwitchMasaConfigGui`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@ mod.version=4.0
 ## Annotation processor
 dependencies.lombok_version=1.18.38
 ## MagicLib
-dependencies.magiclib_dependency=0.8.693
-dependencies.magiclib_version=0.8.693
+dependencies.magiclib_dependency=0.8.697-beta
+dependencies.magiclib_version=0.8.697-beta
 
 # Gradle Plugins
 architectury_loom_version=1.10-SNAPSHOT

--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -8,9 +8,9 @@ dependencies.api.fabric_api_version=0.104.0+2.0.14+1.21.1
 
 # Compatible Libraries
 dependencies.api.itemscroller_version=0.2.2-mc1.21.1
-dependencies.api.litematica_version=0.2.3-mc1.21.1
-dependencies.api.minihud_version=0.2.2-mc1.21.1
-dependencies.api.tweakeroo_version=0.2.4-mc1.21.1
+dependencies.api.litematica_version=0.3.1-mc1.21.1
+dependencies.api.minihud_version=0.3.1-mc1.21.1
+dependencies.api.tweakeroo_version=0.3.1-mc1.21.1
 
 # Loom Properties
 loom.platform=neoforge


### PR DESCRIPTION
## Summary 
MaFgLib introduces its own ConfigScreenEntrypoint at [MaLiLib-Forge@12b695e](https://github.com/ThinkingStudios/MaLiLib-Forge/commit/12b695e86f473d58b97553d2219381f6f9f10157#diff-e9b44e2ca0f850c2e9b761c76d021f403a6910b1edab4f8641481b39f3256465). It breaks MasaGadget's mod config screen factory scanner. We now preferentially use MaFgLib's factory.