### PR TITLE
Fix (Neo)Forge jij issue

### DIFF
--- a/versions/1.16.5-fabric/build.gradle
+++ b/versions/1.16.5-fabric/build.gradle
@@ -108,15 +108,16 @@ dependencies {
 
     // Dependency
     modApi(annotationProcessor("top.hendrixshen.magiclib:magiclib-all-${project.name}:${project.property("dependencies.magiclib_version")}"))
-    modImplementation(include("com.github.Towdium:PinIn:${project.property("dependencies.pinin_version")}"))
 
     switch (modPlatform) {
         case "fabric":
+            implementation(include("com.github.Towdium:PinIn:${project.property("dependencies.pinin_version")}"))
             break
         case "forge":
             forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
             break
         case "neoforge":
+            forgeDependencies(include("com.github.Towdium:PinIn:${project.property("dependencies.pinin_version")}"))
             neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
             break
     }


### PR DESCRIPTION
## Summary
Manually mark `PinIn` lib as a forge dependency for ease of jij.