### PR TITLE
fix remap

### DIFF
--- a/src/main/java/com/plusls/MasaGadget/mixin/mod_tweak/tweakeroo/inventoryPreviewSupportSelect/MixinInventoryOverlay.java
+++ b/src/main/java/com/plusls/MasaGadget/mixin/mod_tweak/tweakeroo/inventoryPreviewSupportSelect/MixinInventoryOverlay.java
@@ -23,11 +23,12 @@ public class MixinInventoryOverlay {
     @Inject(
             //#if MC >= 12106
             //$$ method = "renderStackAt(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/item/ItemStack;FFFLnet/minecraft/client/Minecraft;DD)V",
+            //$$ remap = true,
             //#elseif MC > 12006
             //$$ method = "renderStackAt(Lnet/minecraft/world/item/ItemStack;FFFLnet/minecraft/client/Minecraft;Lnet/minecraft/client/gui/GuiGraphics;DD)V",
+            //$$ remap = true,
             //#else
             method = "renderStackAt",
-            remap = true,
             //#endif
             at = @At("RETURN")
     )


### PR DESCRIPTION
在MC >= 12106时，设置remap = true，可解决1.21.6及以上版本容器预览崩溃的问题
已在1.20.6，1.21.5，1.21.8三个版本中测试